### PR TITLE
Added plausible_static exception in case of point to point IP

### DIFF
--- a/xivo/xivo_config.py
+++ b/xivo/xivo_config.py
@@ -284,6 +284,11 @@ def plausible_static(static, schema):
     """
     address = network.parse_ipv4(static['address'])
     netmask = network.parse_ipv4(static['netmask'])
+
+    # If point to point configuration (netmask is 255.255.255.255), bypass the tests
+    if netmask[0] == 255 and netmask[1] == 255 and netmask[2] == 255 and netmask[3] == 255 and:
+        return True
+
     if not network.plausible_netmask(netmask):
         return False
     addr_list = [address]


### PR DESCRIPTION
At online.net, we have a specific IP/32 and a specific gateway. This is a point to point IP configuration.
In this case, the tests fails. I added a condition upon the /32 netmask. Hoping that administrator knowns what he does :-)