### PR TITLE
Expose visible_tenants

### DIFF
--- a/xivo/tenant_flask_helpers.py
+++ b/xivo/tenant_flask_helpers.py
@@ -70,3 +70,24 @@ class Tenant(tenant_helpers.Tenant):
         except tenant_helpers.InvalidTenant:
             logger.debug('Tenant invalid against token')
             raise tenant_helpers.UnauthorizedTenant(tenant.uuid)
+
+
+def get_requested_tenant():
+    requested_tenant = g.get('requested_tenant')
+    if not requested_tenant:
+        requested_tenant = g.requested_tenant = Tenant.autodetect()
+    return requested_tenant
+
+
+requested_tenant = LocalProxy(get_requested_tenant)
+
+
+def get_visible_tenants():
+    visible_tenants = g.get('visible_tenants')
+    if not visible_tenants:
+        visible_tenants = g.visible_tenants = tenant_helpers.visible_tenants(
+            auth_client, requested_tenant.uuid)
+    return visible_tenants
+
+
+visible_tenants = LocalProxy(get_visible_tenants)


### PR DESCRIPTION
There is two ways to have the tenant_uuid:
1) user don't request any and we use the one from the token
2) user request a special one inside a header

For 1), we can get visible tenants by just using token.visible_tenants()
For 2), we don't have helper, each project have a slightly modified
version of token.visible_tenants() to just replace token.tenant_uuid by
tenant_flask_helpers.Tenant.autodetect().uuid

This change exposes visible_tenants and requested_tenant.